### PR TITLE
Fixed #485: NMA: thin by default

### DIFF
--- a/mtc-mcmc/src/integration-test/java/org/drugis/mtc/ConsistencyModelTestBase.java
+++ b/mtc-mcmc/src/integration-test/java/org/drugis/mtc/ConsistencyModelTestBase.java
@@ -73,6 +73,8 @@ abstract public class ConsistencyModelTestBase {
 		d_network.getStudies().addAll(Arrays.asList(d_s1, d_s2, d_s3));
 		
 		d_model = createModel(d_network);
+		d_model.setSimulationIterations(100000);
+
 	}
 	
 	abstract protected ConsistencyModel createModel(Network network);

--- a/mtc-mcmc/src/integration-test/java/org/drugis/mtc/InconsistencyModelTestBase.java
+++ b/mtc-mcmc/src/integration-test/java/org/drugis/mtc/InconsistencyModelTestBase.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 abstract public class InconsistencyModelTestBase {
-	private static final double FACTOR = 0.05;
+	private static final double FACTOR = 0.10;
 	
 	private Mean d_mean = new Mean();
 	private StandardDeviation d_stdDev = new StandardDeviation();
@@ -73,8 +73,9 @@ abstract public class InconsistencyModelTestBase {
 		d_network = new Network();
 		d_network.getTreatments().addAll(Arrays.asList(d_ta, d_tb, d_tc));
 		d_network.getStudies().addAll(Arrays.asList(d_s1, d_s2, d_s3));
-		
 		d_model = createModel(d_network);
+		d_model.setSimulationIterations(100000);
+
 	}
 
 	abstract protected InconsistencyModel createModel(Network network);

--- a/mtc-mcmc/src/integration-test/java/org/drugis/mtc/yadas/ContinuousDataIT.java
+++ b/mtc-mcmc/src/integration-test/java/org/drugis/mtc/yadas/ContinuousDataIT.java
@@ -67,6 +67,7 @@ public class ContinuousDataIT {
 	public void testResult() throws InterruptedException {
 		YadasConsistencyModel model = new YadasConsistencyModel(d_network);
 		model.setExtendSimulation(ExtendSimulation.FINISH);
+		model.setSimulationIterations(100000);
 		TaskUtil.run(model.getActivityTask());
 		
 		assertTrue(model.isReady());

--- a/mtc-mcmc/src/integration-test/java/org/drugis/mtc/yadas/YadasNodeSplitIT.java
+++ b/mtc-mcmc/src/integration-test/java/org/drugis/mtc/yadas/YadasNodeSplitIT.java
@@ -61,6 +61,7 @@ public class YadasNodeSplitIT {
 	public void testResult() throws InterruptedException {
 		YadasNodeSplitModel model = new YadasNodeSplitModel(d_network, new BasicParameter(d_mpci, d_spci));
 		model.setExtendSimulation(ExtendSimulation.FINISH);
+		model.setSimulationIterations(100000);
 		TaskUtil.run(model.getActivityTask());
 		
 		assertTrue(model.isReady());

--- a/mtc-mcmc/src/main/java/org/drugis/mtc/yadas/AbstractYadasModel.java
+++ b/mtc-mcmc/src/main/java/org/drugis/mtc/yadas/AbstractYadasModel.java
@@ -83,7 +83,9 @@ public abstract class AbstractYadasModel implements MCMCModel {
 		
 		public void doStep() {
 			update(d_chain);
-			output(d_chain);
+			if(d_iteration % THINNING_INTERVAL == 0) { 
+				output(d_chain);
+			}
 		}
 	}
 
@@ -113,9 +115,9 @@ public abstract class AbstractYadasModel implements MCMCModel {
 		}
 	}
 	
-	protected static final int THINNING_INTERVAL = 1;
+	protected static final int THINNING_INTERVAL = 10;
 	protected static final double VARIANCE_SCALING = 2.5;
-	protected static final int SIMULATION_ITERATIONS_EXTENSION = 60000;
+	protected static final int SIMULATION_ITERATIONS_EXTENSION = 50000;
 
 	protected abstract void createChain(int chain);
 
@@ -123,7 +125,7 @@ public abstract class AbstractYadasModel implements MCMCModel {
 	private List<List<MCMCUpdate>> d_updateList = new ArrayList<List<MCMCUpdate>>();
 	private int d_reportingInterval = 100;
 	protected YadasResults d_results = new YadasResults();
-	private YadasSettings d_settings = new YadasSettings(20000, 60000, 4);
+	private YadasSettings d_settings = new YadasSettings(20000, 50000, 4);
 	private ActivityTask d_activityTask;
 	private SimpleSuspendableTask d_finalPhase;
 	protected ExtendSimulation d_extendSimulation = ExtendSimulation.WAIT;
@@ -157,7 +159,7 @@ public abstract class AbstractYadasModel implements MCMCModel {
 				for(ExtendableIterativeTask t : simulationPhase) {
 					t.extend(SIMULATION_ITERATIONS_EXTENSION);
 				}
-				d_results.setNumberOfIterations(getSimulationIterations() + SIMULATION_ITERATIONS_EXTENSION);
+				d_results.setNumberOfIterations((getSimulationIterations() + SIMULATION_ITERATIONS_EXTENSION) / THINNING_INTERVAL);
 				d_settings.setSimulationIterations(d_results.getNumberOfIterations());
 				// Finally, reset the decision phase. Must be done after the simulations are extended, otherwise it becomes a next state.
 				d_notifyResults.reset();
@@ -232,7 +234,7 @@ public abstract class AbstractYadasModel implements MCMCModel {
 	private void buildModel() {
 		prepareModel();
 		d_results.setNumberOfChains(getNumberOfChains());
-		d_results.setNumberOfIterations(getSimulationIterations());
+		d_results.setNumberOfIterations(getSimulationIterations() / THINNING_INTERVAL);
 		d_results.setDirectParameters(getParameters());
 		d_results.setDerivedParameters(getDerivedParameters());	
 	

--- a/mtc-mcmc/src/main/java/org/drugis/mtc/yadas/YadasResults.java
+++ b/mtc-mcmc/src/main/java/org/drugis/mtc/yadas/YadasResults.java
@@ -67,18 +67,22 @@ public class YadasResults implements MCMCResults {
 	}
 	
 	public YadasResults() {
-		clear();
+		initialize();
 	}
 
 	@Override
 	public void clear() {
+		d_availableSamples = 0;
+		d_reservedSamples = 0;
+		initResults();
+	}
+	
+	private void initialize() { 
 		d_directParameters = new Parameter[] {};
 		d_derivedParameters = new Parameter[] {};
 		d_derivations = new Derivation[] {};
 		d_nChains = 0;
-		d_availableSamples = 0;
-		d_reservedSamples = 0;
-		initResults();
+		clear();
 	}
 
 	/**

--- a/mtc-mcmc/src/test/java/org/drugis/mtc/yadas/YadasConsistencyModelTest.java
+++ b/mtc-mcmc/src/test/java/org/drugis/mtc/yadas/YadasConsistencyModelTest.java
@@ -53,7 +53,7 @@ public class YadasConsistencyModelTest {
 
 	@Test 
 	public void testSimulationIterations() {
-		assertEquals(60000, d_model.getSimulationIterations());
+		assertEquals(50000, d_model.getSimulationIterations());
 		d_model.setSimulationIterations(10000);
 		assertEquals(10000, d_model.getSimulationIterations());
 	}


### PR DESCRIPTION
- Fixed #485: NMA: thin by default
- Do not reset chains and parameters on clear
